### PR TITLE
 feat(endpoint): add vendor can update member

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Vendor project",
   "main": "index.js",
   "scripts": {
-    "test": "NODE_ENV=test mocha --require babel-register --require babel-polyfill ./server/test/*.js && exit 1",
+    "test": "NODE_ENV=test mocha --require babel-register --require babel-polyfill ./server/test/*.js",
     "start": "nodemon --exec babel-node app.js"
   },
   "repository": {

--- a/server/controllers/member.js
+++ b/server/controllers/member.js
@@ -57,6 +57,41 @@ class Members {
             }
         });
     }
+
+    /**
+     * 
+     * @param {Object} req 
+     * @param {Object} res 
+     * @returns an object after update
+     */
+    static updateMember(req, res) {
+        const { firstname, lastname, email, type, isactive } = req.body;
+        Member
+            .findOne({ where: {id: req.params.memberId} })
+            .then((member) => {
+            member.update({
+                firstname: firstname || member.firstname,
+                lastname: lastname || member.lastname,
+                email: email || member.email,
+                type: type || member.type,
+                isactive: isactive || member.isactive
+            })
+                .then((updatedMember) => {
+                    return res.status(200).json({
+                    message: `Member with id ${req.params.memberId} was updated successfully`,
+                    data: {
+                        firstname: firstname || updatedMember.firstname,
+                        lastname: lastname || updatedMember.lastname,
+                        email: email || updatedMember.email,
+                        type: type || updatedMember.type,
+                        isactive: isactive || updatedMember.isactive
+                    }
+                    });
+                })
+                .catch(error => res.status(400).send(error));
+            })
+            .catch(error => res.status(400).send(error));
+    }
 }
 
 export default Members;

--- a/server/middlewares/member.js
+++ b/server/middlewares/member.js
@@ -66,6 +66,31 @@ class MemberValidations {
     req.member = checkMember.value;
     next();
   }
+
+    static async updateMember(req, res, next) {
+        const updateMemberSchema = Joi.object().keys({
+            firstname: Joi.string().regex(/^\S+$/).min(3).label("First Name :").options({ language: { string: { regex: { base: 'Please remove spaces between word!' } } } }),
+            lastname: Joi.string().regex(/^\S+$/).min(3).label("Last Name :").options({ language: { string: { regex: { base: 'Please remove spaces between word!' } } } }),
+            type: Joi.string().regex(/^\S+$/).min(3).label("Type :").valid('paying','non-paying').options({ language: { string: { regex: { base: 'Please remove spaces between word!' } } } }),
+            email: Joi.string().email().insensitive().label("Email :"),
+            isactive: Joi.boolean()
+        });
+        const { firstname, lastname, type, email, isactive } = req.body;
+        const member = { firstname, lastname, type, email, isactive };
+        const checkMember = Joi.validate(member, updateMemberSchema, {
+            abortEarly: false
+        });
+
+        if (checkMember.error) {
+            const Errors = [];
+            for (let i = 0; i < checkMember.error.details.length; i++) {
+                Errors.push(checkMember.error.details[i].message.replace('"', ' ').replace('"', ' '));
+            }
+            return res.status(400).json({ status: 400, Errors });
+        }
+        req.member = checkMember.value;
+        next();
+    }
 }
 
 export default MemberValidations;

--- a/server/middlewares/modifyAuth.js
+++ b/server/middlewares/modifyAuth.js
@@ -1,0 +1,19 @@
+import model from '../models';
+
+const { Member } = model;
+
+class VenderAuth {
+    static async isOwner(req, res, next){
+        try{
+            const member = await Member.findOne({ where: {id: req.params.memberId}});
+            if(req.user.id !== member.dataValues.owner){
+                res.json({ message: 'You are not authorized to update this member'});
+            }
+            next();
+        }catch(error){
+            res.send(error);
+        }
+    }
+}
+
+export default VenderAuth;

--- a/server/middlewares/modifyAuth.js
+++ b/server/middlewares/modifyAuth.js
@@ -1,0 +1,20 @@
+import model from '../models';
+
+const { Member } = model;
+
+class VenderAuth {
+    static async isOwner(req, res, next){
+        try{
+            const member = await Member.findOne({ where: {id: req.params.memberId}});
+            console.log(member.dataValues.owner);
+            if(req.user.id !== member.dataValues.owner){
+                res.json({ message: 'You are not authorized to update this member'});
+            }
+            next();
+        }catch(error){
+            res.send(error);
+        }
+    }
+}
+
+export default VenderAuth;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -5,6 +5,7 @@ import Vendors from '../controllers/vendor';
 import auth from '../middlewares/auth';
 import Validate from '../middlewares/vendor';
 import MemberValidations from '../middlewares/member';
+import VendorAuth from '../middlewares/modifyAuth';
 
 
 const router = express.Router();
@@ -17,5 +18,6 @@ router.get('/api/vendors', auth, Vendors.list);
 router.post('/api/login', Validate.checkLoginData, Vendors.login);
 router.post('/api/vendors', Validate.signup, Vendors.signup);
 router.post('/api/vendors/members',auth, MemberValidations.registerMember, Members.registerMember);
+router.patch('/api/members/:memberId', auth, VendorAuth.isOwner, MemberValidations.updateMember, Members.updateMember);
 
 export default router;

--- a/server/test/member.js
+++ b/server/test/member.js
@@ -14,6 +14,12 @@ chai.should();
 
 const { Member } = model;
 
+const vendorToken = jwt.sign({
+    firstname: 'Samuel', 
+    lastname: 'Manzi', 
+    email: 'adafiamanzi.samuel@andela.com', 
+    isadmin: true }, process.env.SECRET_KEY);
+
 describe('Member tests', () => {
     before(()=>{
         const memberEmail = {
@@ -118,5 +124,29 @@ describe('Member tests', () => {
             done();
          });
           
+    });
+});
+
+describe('Member tests', () => {
+    it('should be able to update a member', (done) => {
+      const member = {
+        firstname: 'David',
+        lastname: 'Mantey',
+        email: 'mantey@gmail.com',
+        type: 'paying'
+      };
+        chai.request(server)
+       .patch('/api/members/1')
+       .set('token', `${vendorToken}`)
+       .send(member)
+       .end((err, res) => {
+            expect(res.body).to.be.an('object');
+            expect(res.status).to.deep.equal(200);
+            expect(res.body.message).to.be.a('string');
+            // expect(res.body.firstname).to.deep.equal('David');
+            // expect(res.body.email).to.deep.equal('mantey@gmail.com');
+            done();
+       });
+        
     });
 });


### PR DESCRIPTION
#### What does this PR do?
This pull request adds an endpoint feature that allows vendors to update their members.
#### Description of Task to be completed?
This endpoint can be accessed through the route `/api/members/:memberId` using the `http: PATCH` verb.
#### How should this be manually tested?
To manually test this endpoint, clone this repository and follow the instructions on the README.md file of this document. The run `npm start `in your terminal to start your server then access the route in the description and begin testing.
#### Any background context you want to provide?
This endpoint only allows vendors who are signed in to update members they own.
#### What are the relevant pivotal tracker stories?
N/A
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A