### PR TITLE
Add API endpoint for deleting an existing member

### DIFF
--- a/server/controllers/member.js
+++ b/server/controllers/member.js
@@ -31,7 +31,7 @@ class Members {
             email: req.member.email.toLowerCase(),
             type: req.member.type,
             isactive: true,
-            owner:req.user.id
+            owner: req.user.id
         };
 
         Member.findOne({
@@ -39,23 +39,23 @@ class Members {
                 email: req.member.email,
             }
         })
-        .then(member => {
-            if (member) {
-                res.status(409).json({ error: 'Member already recorded!' });
-            }
-            else{
-                Member.create(memberData)
-                .then(member => {
-                    return res.status(201).json({
-                        message:"Member Created successfully",
-                        data: memberData
-                    });
-                })
-                .catch(err => {
-                    res.status(400).send('error' + err);
-                });
-            }
-        });
+            .then(member => {
+                if (member) {
+                    res.status(409).json({ error: 'Member already recorded!' });
+                }
+                else {
+                    Member.create(memberData)
+                        .then(member => {
+                            return res.status(201).json({
+                                message: "Member Created successfully",
+                                data: memberData
+                            });
+                        })
+                        .catch(err => {
+                            res.status(400).send('error' + err);
+                        });
+                }
+            });
     }
 
     /**
@@ -67,30 +67,38 @@ class Members {
     static updateMember(req, res) {
         const { firstname, lastname, email, type, isactive } = req.body;
         Member
-            .findOne({ where: {id: req.params.memberId} })
+            .findOne({ where: { id: req.params.memberId } })
             .then((member) => {
-            member.update({
-                firstname: firstname || member.firstname,
-                lastname: lastname || member.lastname,
-                email: email || member.email,
-                type: type || member.type,
-                isactive: isactive || member.isactive
-            })
-                .then((updatedMember) => {
-                    return res.status(200).json({
-                    message: `Member with id ${req.params.memberId} was updated successfully`,
-                    data: {
-                        firstname: firstname || updatedMember.firstname,
-                        lastname: lastname || updatedMember.lastname,
-                        email: email || updatedMember.email,
-                        type: type || updatedMember.type,
-                        isactive: isactive || updatedMember.isactive
-                    }
-                    });
+                member.update({
+                    firstname: firstname || member.firstname,
+                    lastname: lastname || member.lastname,
+                    email: email || member.email,
+                    type: type || member.type,
+                    isactive: isactive || member.isactive
                 })
-                .catch(error => res.status(400).send(error));
+                    .then((updatedMember) => {
+                        return res.status(200).json({
+                            message: `Member with id ${req.params.memberId} was updated successfully`,
+                            data: {
+                                firstname: firstname || updatedMember.firstname,
+                                lastname: lastname || updatedMember.lastname,
+                                email: email || updatedMember.email,
+                                type: type || updatedMember.type,
+                                isactive: isactive || updatedMember.isactive
+                            }
+                        });
+                    })
+                    .catch(error => res.status(400).send(error));
             })
             .catch(error => res.status(400).send(error));
+    }
+
+    static async deleteMember(req, res) {
+        const member = await Member.findByPk(req.params.memberId);
+        member.destroy();
+            return res.status(200).json({
+                message: `Member with id ${req.params.memberId} was successfully deleted`
+            });
     }
 }
 

--- a/server/middlewares/member.js
+++ b/server/middlewares/member.js
@@ -75,20 +75,39 @@ class MemberValidations {
             email: Joi.string().email().insensitive().label("Email :"),
             isactive: Joi.boolean()
         });
-        const { firstname, lastname, type, email, isactive } = req.body;
-        const member = { firstname, lastname, type, email, isactive };
+
+        const member = { 
+            firstname: req.body.firstname, 
+            lastname: req.body.lastname, 
+            type: req.body.type, 
+            email: req.body.email, 
+            isactive: req.body.isactive, 
+        };
         const checkMember = Joi.validate(member, updateMemberSchema, {
             abortEarly: false
         });
-
         if (checkMember.error) {
             const Errors = [];
             for (let i = 0; i < checkMember.error.details.length; i++) {
                 Errors.push(checkMember.error.details[i].message.replace('"', ' ').replace('"', ' '));
             }
-            return res.status(400).json({ status: 400, Errors });
+            return res.status(400).json({ status: 400, message: Errors[0] });
         }
-        req.member = checkMember.value;
+        next();
+    }
+
+    static async urlMember(req, res, next) {
+        const urlSchema = Joi.object().keys({
+            memberId: Joi.number().positive().required()
+        });
+        const memberData = {
+            memberId: req.params.memberId
+        };
+        const checkUrl = Joi.validate(memberData, urlSchema);
+
+        if(checkUrl.error){
+            return res.status(400).json({message: checkUrl.error.details[0].message.replace('"', ' ').replace('"', ' ')});
+        }
         next();
     }
 }

--- a/server/middlewares/modifyAuth.js
+++ b/server/middlewares/modifyAuth.js
@@ -6,12 +6,16 @@ class VenderAuth {
     static async isOwner(req, res, next){
         try{
             const member = await Member.findOne({ where: {id: req.params.memberId}});
-            if(req.user.id !== member.dataValues.owner){
-                res.json({ message: 'You are not authorized to update this member'});
+            if(member === null) {
+                return res.status(404).send({
+                    message : "Member was not found"
+                });
+            }else if(req.user.id !== member.dataValues.owner){
+                return res.json({ message: 'You are not authorized to update this member'});
             }
             next();
         }catch(error){
-            res.send(error);
+            return res.send(error);
         }
     }
 }

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -18,6 +18,7 @@ router.get('/api/vendors', auth, Vendors.list);
 router.post('/api/login', Validate.checkLoginData, Vendors.login);
 router.post('/api/vendors', Validate.signup, Vendors.signup);
 router.post('/api/vendors/members',auth, MemberValidations.registerMember, Members.registerMember);
-router.patch('/api/members/:memberId', auth, VendorAuth.isOwner, MemberValidations.updateMember, Members.updateMember);
+router.patch('/api/members/:memberId', MemberValidations.urlMember, auth, VendorAuth.isOwner, MemberValidations.updateMember, Members.updateMember);
+router.delete('/api/members/:memberId', MemberValidations.urlMember, auth, VendorAuth.isOwner, Members.deleteMember);
 
 export default router;

--- a/server/test/member.js
+++ b/server/test/member.js
@@ -14,11 +14,8 @@ chai.should();
 
 const { Member } = model;
 
-const vendorToken = jwt.sign({
-    firstname: 'Samuel', 
-    lastname: 'Manzi', 
-    email: 'adafiamanzi.samuel@andela.com', 
-    isadmin: true }, process.env.SECRET_KEY);
+const venderInfo = {id: 1, firstname: 'Samuel', lastname: 'Manzi', email: 'adafiamanzi.samuel@andela.com', isadmin: true };
+const vendorToken = jwt.sign(venderInfo, process.env.SECRET_KEY);
 
 describe('Member tests', () => {
     before(()=>{
@@ -128,25 +125,166 @@ describe('Member tests', () => {
 });
 
 describe('Member tests', () => {
-    it('should be able to update a member', (done) => {
-      const member = {
-        firstname: 'David',
-        lastname: 'Mantey',
-        email: 'mantey@gmail.com',
-        type: 'paying'
-      };
+    before('A member should be created before updating test is run',(done)=> {
+        const memberData = {
+            firstname:'Kwame',
+            lastname:'Junior',
+            email:'junior@gmail.com',
+            type:'non-paying',
+            owner: venderInfo.id,
+        };
         chai.request(server)
-       .patch('/api/members/1')
+         .post('/api/vendors/members')
+         .set('token', vendorToken)
+         .send(memberData)
+         .end((err, res) => {
+            expect(res.body).to.be.an('object');
+            done();
+         });
+    });
+    it('should be able to update a member', async () => {
+        const memberOwner = await Member.findOne({ where: { email: 'junior@gmail.com'}});
+        const member = {
+            firstname:'Qwame',
+            lastname:'Junior',
+            email:'junior@gmail.com',
+            type: 'paying'
+        };
+        chai.request(server)
+       .patch(`/api/members/${memberOwner.dataValues.id}`)
        .set('token', `${vendorToken}`)
        .send(member)
        .end((err, res) => {
             expect(res.body).to.be.an('object');
             expect(res.status).to.deep.equal(200);
-            expect(res.body.message).to.be.a('string');
-            // expect(res.body.firstname).to.deep.equal('David');
-            // expect(res.body.email).to.deep.equal('mantey@gmail.com');
+            expect(res.body.message).to.deep.equal(`Member with id ${memberOwner.dataValues.id} was updated successfully`);
+            expect(res.body.data.email).to.deep.equal(member.email);
+       });
+    });
+    it('should not update a member if the email is invalid', async () => {
+        const memberOwner = await Member.findOne({ where: { email: 'junior@gmail.com'}});
+        const member = {
+            firstname:'Qwame',
+            lastname:'Junior',
+            email:'juniorgmail.com',
+            type: 'paying'
+        };
+        chai.request(server)
+       .patch(`/api/members/${memberOwner.dataValues.id}`)
+       .set('token', `${vendorToken}`)
+       .send(member)
+       .end((err, res) => {
+            expect(res.body).to.be.an('object');
+            expect(res.status).to.deep.equal(400);
+            expect(res.body.message).to.deep.equal(' Email :  must be a valid email');
+       });
+    });
+    it('should not update a member if the id provided does not exist', (done) => {
+        const member = {
+            firstname:'Qwame',
+            lastname:'Junior',
+            email:'junior@gmail.com',
+            type: 'paying'
+        };
+        chai.request(server)
+       .patch('/api/members/1000')
+       .set('token', `${vendorToken}`)
+       .send(member)
+       .end((err, res) => {
+            expect(res.body).to.be.an('object');
+            expect(res.status).to.deep.equal(404);
+            expect(res.body.message).to.deep.equal('Member was not found');
             done();
        });
-        
+    });
+
+    it('should not update a member if the id provided is not a positive number', (done) => {
+        const member = {
+            firstname:'Qwame',
+            lastname:'Junior',
+            email:'junior@gmail.com',
+            type: 'paying'
+        };
+        chai.request(server)
+       .patch('/api/members/-1')
+       .set('token', `${vendorToken}`)
+       .send(member)
+       .end((err, res) => {
+            expect(res.body).to.be.an('object');
+            expect(res.status).to.deep.equal(400);
+            expect(res.body.message).to.deep.equal(' memberId  must be a positive number');
+            done();
+       });
+    });
+
+    it('should not update a member if the id provided is a string', (done) => {
+        const member = {
+            firstname:'Qwame',
+            lastname:'Junior',
+            email:'junior@gmail.com',
+            type: 'paying'
+        };
+        chai.request(server)
+       .patch('/api/members/hjgh')
+       .set('token', `${vendorToken}`)
+       .send(member)
+       .end((err, res) => {
+            expect(res.body).to.be.an('object');
+            expect(res.status).to.deep.equal(400);
+            expect(res.body.message).to.deep.equal(' memberId  must be a number');
+            done();
+       });
+    });
+
+    it('should not to delete a member if the member id does not exist', (done) => {
+        chai.request(server)
+       .delete('/api/members/1000')
+       .set('token', `${vendorToken}`)
+       .end((err, res) => {
+            expect(res.body).to.be.an('object');
+            expect(res.status).to.deep.equal(404);
+            expect(res.body.message).to.deep.equal(`Member was not found`);
+            done();
+       });
+
+    });
+
+    it('should not to delete a member if the member id is not positive', (done) => {
+        chai.request(server)
+       .delete('/api/members/-1')
+       .set('token', `${vendorToken}`)
+       .end((err, res) => {
+            expect(res.body).to.be.an('object');
+            expect(res.status).to.deep.equal(400);
+            expect(res.body.message).to.deep.equal(' memberId  must be a positive number');
+            done();
+       });
+
+    });
+
+    it('should not to delete a member if the member id is a string', (done) => {
+        chai.request(server)
+       .delete('/api/members/string')
+       .set('token', `${vendorToken}`)
+       .end((err, res) => {
+            expect(res.body).to.be.an('object');
+            expect(res.status).to.deep.equal(400);
+            expect(res.body.message).to.deep.equal(' memberId  must be a number');
+            done();
+       });
+
+    });
+
+    it('should be able to delete a member', async () => {
+        const memberOwner = await Member.findOne({ where: { email: 'junior@gmail.com'}});
+        chai.request(server)
+       .delete(`/api/members/${memberOwner.dataValues.id}`)
+       .set('token', `${vendorToken}`)
+       .end((err, res) => {
+            expect(res.body).to.be.an('object');
+            expect(res.status).to.deep.equal(200);
+            expect(res.body.message).to.deep.equal(`Member with id ${memberOwner.dataValues.id} was successfully deleted`);
+       });
+
     });
 });


### PR DESCRIPTION
#### What does this PR do?
This pull request adds an API endpoint feature that gives vendors the opportunity to delete members they own.
#### Description of Task to be completed?
Vendors can only delete members they added/created. This endpoint can be accessed via this route `/api/members/:memberId` using the http `Delete` verb/method.
#### How should this be manually tested?
Refer to the `README.md` file of this repository for steps to follow in setting up this project.
#### Any background context you want to provide?
Members are clients or customers that vendors record to keep track of people who patronize their goods or services
#### What are the relevant pivotal tracker stories?
N/A
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A